### PR TITLE
Include the possible cross-compiler targets in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The most popular targets are:
 
 - **Windows:** `x86_64-w64-mingw32`
 - **Linux:** `x86_64-linux-musl`,
-- **macOS:** `aarch64-apple-darwin`  
+- **macOS:** `aarch64-apple-darwin20.2`  
 - **Raspberry Pi:** `arm-linux-musleabihf`  
 
 The full list of supported targets varies from release to release and between host platforms. See file `toolchains/etc/crosscompilers.sha256` to check which targets your release supports

--- a/README.md
+++ b/README.md
@@ -142,25 +142,21 @@ an appropriate cross-compiler from the current `4diac-toolchains` release.
 See `toolchains/etc/crosscompilers.sha256` for a list of pre-built
 crosscompilers for the current release.
 
-Cross-compilers are based on a triple configuration. Take **x86_64-linux-gnu** as an example:
+Cross-compilers are based on a triple configuration. Take **x86_64-linux-musl** as an example:
+
 
 - The first part (**x86_64**) represents the CPU architecture.  
-- The second part (**linux**) specifies the operating system—common values include **linux**, **w64** (for Windows), or **none** (for bare-metal targets).  
-- The third part (**gnu**) indicates the C standard library and ABI, such as **gnu**, **musl**, or **eabi** (for bare-metal), and may also include details like hard or soft-float support.  
+- The second part (**linux**) specifies the operating system.  
+- The third part (**musl**) specifies the calling convention, which might involve also hardware specific details.
 
-For example, a **Raspberry Pi 3** running Linux might use **arm-linux-gnueabihf** or **arm-linux-musleabi**. If running without an operating system, the appropriate cross-compiler would be **arm-none-eabi**.
-
-
-Common but not limited targets are:
+The most popular targets are:
 
 - **Windows:** `x86_64-w64-mingw32`
-- **Linux:** `x86_64-linux-gnu`, `aarch64-linux-gnu`
+- **Linux:** `x86_64-linux-musl`,
 - **macOS:** `aarch64-apple-darwin`  
-- **Raspberry Pi:** `arm-linux-gnueabihf`, `arm-linux-musleabihf`  
-- **Bare-metal (no OS):** `arm-none-eabi`, `riscv32-unknown-elf`
+- **Raspberry Pi:** `arm-linux-musleabihf`  
 
-
-
+The full list of supported targets varies from release to release and between host platforms. See file `toolchains/etc/crosscompilers.sha256` to check which targets your release supports
 
 Adding generated function blocks
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -139,21 +139,8 @@ You can select a cross-compiled build by setting `ARCH` in the build
 configuration file (see above).  If cross-compiling 4diac FORTE for a new
 target architecture for the first time, the build environment will download
 an appropriate cross-compiler from the current `4diac-toolchains` release.
-Targets for the pre-built cross-compilers include:
-
-- x86_64-linux-gnu
-- x86_64-linux-musl
-- x86_64-w64-mingw32
-- i686-linux-musl
-- i686-w64-mingw32
-- arm-linux-gnueabihf
-- arm-linux-musleabihf
-- arm-linux-musleabi
-- arm-none-eabi
-- aarch64-linux-musl
-- aarch64-linux-gnu
-- riscv64-linux-musl
-- riscv32-unknown-elf
+See `toolchains/etc/crosscompilers.sha256` for a list of pre-built
+crosscompilers for the current release.
 
 Cross-compilers are based on a triple configuration. Take **x86_64-linux-gnu** as an example:
 
@@ -162,6 +149,17 @@ Cross-compilers are based on a triple configuration. Take **x86_64-linux-gnu** a
 - The third part (**gnu**) indicates the C standard library and ABI, such as **gnu**, **musl**, or **eabi** (for bare-metal), and may also include details like hard or soft-float support.  
 
 For example, a **Raspberry Pi 3** running Linux might use **arm-linux-gnueabihf** or **arm-linux-musleabi**. If running without an operating system, the appropriate cross-compiler would be **arm-none-eabi**.
+
+
+Common but not limited targets are:
+
+- **Windows:** `x86_64-w64-mingw32`
+- **Linux:** `x86_64-linux-gnu`, `aarch64-linux-gnu`
+- **macOS:** `aarch64-apple-darwin`  
+- **Raspberry Pi:** `arm-linux-gnueabihf`, `arm-linux-musleabihf`  
+- **Bare-metal (no OS):** `arm-none-eabi`, `riscv32-unknown-elf`
+
+
 
 
 Adding generated function blocks

--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Targets for the pre-built cross-compilers include:
 - riscv64-linux-musl
 - riscv32-unknown-elf
 
+Cross-compilers are based on a triple configuration. Take **x86_64-linux-gnu** as an example:
+
+- The first part (**x86_64**) represents the CPU architecture.  
+- The second part (**linux**) specifies the operating system—common values include **linux**, **w64** (for Windows), or **none** (for bare-metal targets).  
+- The third part (**gnu**) indicates the C standard library and ABI, such as **gnu**, **musl**, or **eabi** (for bare-metal), and may also include details like hard or soft-float support.  
+
+For example, a **Raspberry Pi 3** running Linux might use **arm-linux-gnueabihf** or **arm-linux-musleabi**. If running without an operating system, the appropriate cross-compiler would be **arm-none-eabi**.
+
 
 Adding generated function blocks
 --------------------------------

--- a/README.md
+++ b/README.md
@@ -139,8 +139,21 @@ You can select a cross-compiled build by setting `ARCH` in the build
 configuration file (see above).  If cross-compiling 4diac FORTE for a new
 target architecture for the first time, the build environment will download
 an appropriate cross-compiler from the current `4diac-toolchains` release.
-See `toolchains/etc/crosscompilers.sha256` for a list of pre-built
-crosscompilers for the current release.
+Targets for the pre-built crosscompilers include:
+
+- x86_64-linux-gnu
+- x86_64-linux-musl
+- x86_64-w64-mingw32
+- i686-linux-musl
+- i686-w64-mingw32
+- arm-linux-gnueabihf
+- arm-linux-musleabihf
+- arm-linux-musleabi
+- arm-none-eabi
+- aarch64-linux-musl
+- aarch64-linux-gnu
+- riscv64-linux-musl
+- riscv32-unknown-elf
 
 
 Adding generated function blocks

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can select a cross-compiled build by setting `ARCH` in the build
 configuration file (see above).  If cross-compiling 4diac FORTE for a new
 target architecture for the first time, the build environment will download
 an appropriate cross-compiler from the current `4diac-toolchains` release.
-Targets for the pre-built crosscompilers include:
+Targets for the pre-built cross-compilers include:
 
 - x86_64-linux-gnu
 - x86_64-linux-musl

--- a/README.md
+++ b/README.md
@@ -142,21 +142,25 @@ an appropriate cross-compiler from the current `4diac-toolchains` release.
 See `toolchains/etc/crosscompilers.sha256` for a list of pre-built
 crosscompilers for the current release.
 
-Cross-compilers are based on a triple configuration. Take **x86_64-linux-musl** as an example:
-
+Cross-compilers are based on a triple configuration. Take
+**x86_64-linux-musl** as an example:
 
 - The first part (**x86_64**) represents the CPU architecture.  
 - The second part (**linux**) specifies the operating system.  
-- The third part (**musl**) specifies the calling convention, which might involve also hardware specific details.
+- The third part (**musl**) specifies the calling convention, which might
+  also involve hardware specific details.
 
 The most popular targets are:
 
 - **Windows:** `x86_64-w64-mingw32`
-- **Linux:** `x86_64-linux-musl`,
+- **Linux:** `x86_64-linux-musl`
 - **macOS:** `aarch64-apple-darwin20.2`  
 - **Raspberry Pi:** `arm-linux-musleabihf`  
 
-The full list of supported targets varies from release to release and between host platforms. See file `toolchains/etc/crosscompilers.sha256` to check which targets your release supports
+The full list of supported targets varies from release to release and between
+host platforms. See file `toolchains/etc/crosscompilers.sha256` to check which
+targets your release supports
+
 
 Adding generated function blocks
 --------------------------------


### PR DESCRIPTION
The sha256 file is ~not included anymore in the shipping of the toolchain~ an auto generated file which is only available in the release download.

This little change provides a better overview of the possible cross-compiler targets for new users.
