### PR TITLE
Streamline CONTRIBUTING.md with new contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,70 +4,63 @@ Thanks for your interest in this project.
 
 ## Project description
 
-Eclipse 4diac™ in its current form has been started 2007 as an open source
-project fostering the further development of IEC 61499 for its use in
-distributed Industrial Process Measurement and Control Systems (IPMCS) and to
-further distribute research results from the original contributors. From the
-beginning, it has provided everything that is necessary to program and execute
-distributed IPMCS.
+[Eclipse 4diac](https://eclipse.dev/4diac) is an Open Source Framework for Industrial Automation & Control. 
+It is a reference implementation for the IEC 61499 standard. 
+IEC 61499 defines a domain specific modeling language for developing distributed industrial control solutions.
+IEC 61499 extends IEC 61131-3 by improving the encapsulation of software components for increased re-usability, providing a vendor independent format, and simplifying support for controller to controller communication.
+Its distribution functionality and the inherent support for dynamic reconfiguration provide the required infrastructure for Industry 4.0 and industrial IoT applications.
 
-* https://projects.eclipse.org/projects/iot.4diac
+### What is 4diac FBE
 
-## Developer resources
+[4diac FBE](https://eclipse.dev/4diac/4diac_fbe/) is a build environment for building [4diac FORTE](https://eclipse.dev/4diac/4diac_forte/). 
+Part of its workflow is code generation and re-compilation of 4diac FORTE. 
+4diac FBE provides the means to do this with as little effort as possible.
+Furthermore, you can manage multiple builds for multiple target platforms.
 
-Information regarding source code management, builds, coding standards, and
-more.
 
-* https://projects.eclipse.org/projects/iot.4diac/developer
+## Terms of Use
 
-The project maintains the following source code repositories
+This repository is subject to the [Terms of Use of the Eclipse Foundation](https://www.eclipse.org/legal/termsofuse.php).
 
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.examples
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.forte
-* https://git.eclipse.org/r/plugins/gitiles/4diac/org.eclipse.4diac.ide
+## Ways to Contribute
 
-This project uses Bugzilla to track ongoing development and issues.
+Contributions are welcome in many forms including:
 
-* Search for issues: https://bugs.eclipse.org/bugs/buglist.cgi?product=4DIAC
-* Create a new report:
-   https://bugs.eclipse.org/bugs/enter_bug.cgi?product=4DIAC
+- bug reports and issue reproduction
+- code contributions
+- documentation improvements
+- testing and validation
 
-Be sure to search for existing bugs before you create another one. Remember that
-contributions are always welcome!
+See the [Eclipse 4diac contribute page](https://eclipse.dev/4diac/contribute/) for details.
 
-An overview on what kinds of contributions are possible can be found here:
-* https://www.eclipse.org/4diac/en_contribute.php
 
-A detailed decomentation of the contribution process here:
-* https://www.eclipse.org/4diac/en_help.php?helppage=html/development/contribute.html
+## Contribution Guide
 
+The development workflow, pull request process, commit guidelines, and testing expectations are described in the 
+[Eclipse 4diac contribution guide](https://eclipse.dev/4diac/doc/development/contribute.html)
 
 ## Eclipse Development Process
 
-This Eclipse Foundation open project is governed by the Eclipse Foundation
-Development Process and operates under the terms of the Eclipse IP Policy.
-
-* https://eclipse.org/projects/dev_process
-* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
+This project operates under the [Eclipse Foundation development process](https://eclipse.org/projects/dev_process) and [IP policy](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf).
 
 ## Eclipse Contributor Agreement
 
-In order to be able to contribute to Eclipse Foundation projects you must
-electronically sign the Eclipse Contributor Agreement (ECA).
+Before your contribution can be accepted you must sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
 
-* http://www.eclipse.org/legal/ECA.php
+The ECA provides the Eclipse Foundation with a permanent record that you agree that each of your contributions will comply with the commitments documented in the Developer Certificate of Origin (DCO). 
+Having an ECA on file associated with the email address matching the "Author" field of your contribution's Git commits fulfills the DCO's requirement that you sign-off on your contributions.
 
-The ECA provides the Eclipse Foundation with a permanent record that you agree
-that each of your contributions will comply with the commitments documented in
-the Developer Certificate of Origin (DCO). Having an ECA on file associated with
-the email address matching the "Author" field of your contribution's Git commits
-fulfills the DCO's requirement that you sign-off on your contributions.
+For more information, please see the [Eclipse Committer Handbook](https://www.eclipse.org/projects/handbook/#resources-commit)
 
-For more information, please see the Eclipse Committer Handbook:
-https://www.eclipse.org/projects/handbook/#resources-commit
+
+**Ensure that:**
+- the email in your Git commits matches your Eclipse account
+- your GitHub username is linked to your Eclipse account
+
 
 ## Contact
 
-Contact the project developers via the project's "dev" list.
+Project discussions take place via:
 
-* https://dev.eclipse.org/mailman/listinfo/4diac-dev
+- [GitHub Discussions](https://github.com/eclipse-4diac/4diac-fbe/discussions)
+- [Eclipse 4diac mailing list](https://accounts.eclipse.org/mailing-list/4diac-dev)


### PR DESCRIPTION
To reduce duplicated information the CONTRIBUTING.md now focuses on the core repo specific topics and otherwise links to the respective pages on our web-page.

Furthermore relevant sections from the Eclipse project handbook's template for contributing.md have been added.